### PR TITLE
Add board submodules (conversion, debug, mailbox120)

### DIFF
--- a/src/board/mod.rs
+++ b/src/board/mod.rs
@@ -1,1 +1,3 @@
-// place-holder
+pub mod conversion;
+pub mod debug;
+pub mod mailbox120;


### PR DESCRIPTION
I added the 'board' submodule declarationss to 'mod.rs', enabling the 'conversion', 'debug' and 'mailbox120' submodules.